### PR TITLE
Fix reference parsing to support registry with port

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ dev-helm: uninstall-helm compile build-dev push-dev install-helm ## Publish with
 
 .PHONY: test
 test: # Run basic end to end tests with bats
+	go test -v ./...
 	bats -t -T test/bats/e2e.bats
 
 uninstall: ## Uninstalls the plugin from the cluster

--- a/cmd/oras-csi-plugin/main.go
+++ b/cmd/oras-csi-plugin/main.go
@@ -30,7 +30,7 @@ func main() {
 	if *sanityTestRun {
 		log.Infof("<********** Sanity Test Run **********>")
 	}
-	log.Infof("Preparing artifact cache (mode: %s; node-id: %s; root-dir: %s; plugin-data-dir: %s enforce-namespaces: %s)",
+	log.Infof("Preparing artifact cache (mode: %s; node-id: %s; root-dir: %s; plugin-data-dir: %s enforce-namespaces: %t)",
 		*mode, *nodeId, *rootDir, *pluginDataDir, *enforceNamespaces)
 
 	var srv driver.Service
@@ -41,16 +41,16 @@ func main() {
 	case "node":
 		srv, err = driver.NewNodeService(*rootDir, *pluginDataDir, *nodeId, *handlersCount, *enforceNamespaces)
 		if err != nil {
-			log.Error("main - couldn't create node service. Error: %s", err.Error())
+			log.Errorf("main - couldn't create node service. Error: %s", err.Error())
 			return
 		}
 	default:
-		log.Error("main - unrecognized mode = %s", *mode)
+		log.Errorf("main - unrecognized mode = %s", *mode)
 		return
 	}
 
 	// This is the Identity service - "hello I am the ORAS csi!"
 	if err = driver.StartService(&srv, *mode, *csiEndpoint); err != nil {
-		log.Error("main - couldn't start service %s", err.Error())
+		log.Errorf("main - couldn't start service %s", err.Error())
 	}
 }

--- a/pkg/oras/blob.go
+++ b/pkg/oras/blob.go
@@ -27,7 +27,7 @@ func pullBlob(repo *remote.Repository, blobRef string, filename string) (fetchEr
 	defer readCloser.Close()
 
 	// Write the blob to a file
-	log.Info("OCI: Writing %s to %s", desc.Digest.String(), filename)
+	log.Infof("OCI: Writing %s to %s", desc.Digest.String(), filename)
 	file, err := os.Create(filename)
 	if err != nil {
 		return err

--- a/pkg/oras/oras.go
+++ b/pkg/oras/oras.go
@@ -155,7 +155,7 @@ func (mnt *OrasHandler) OrasPull(artifactRoot string, settings orasSettings) err
 	log.Infof("Preparing to pull from remote repository: %s", settings.reference)
 	ctx := context.Background()
 	repo, err := remote.NewRepository(settings.reference)
-	log.Infof("Plain http:", settings.optionsPlainHttp)
+	log.Infof("Plain http: %t", settings.optionsPlainHttp)
 	repo.PlainHTTP = settings.optionsPlainHttp
 	if err != nil {
 		return err
@@ -193,7 +193,7 @@ func (mnt *OrasHandler) OrasPull(artifactRoot string, settings orasSettings) err
 	total := len(manifest.Layers)
 	extractCount := 0
 	for i, layer := range manifest.Layers {
-		log.Infof("Pulling %s, %s of %s", layer.Digest, i, total)
+		log.Infof("Pulling %s, %d of %d", layer.Digest, i, total)
 		filename, found := layer.Annotations["org.opencontainers.image.title"]
 
 		// This shouldn't happen, but you never know!
@@ -282,9 +282,9 @@ func (mnt *OrasHandler) OrasPathToVolume(settings orasSettings) (string, error) 
 	artifactRoot := path.Join(pluginData, artifactDir)
 
 	// If we enforce a namespace, must go under that
-	log.Infof("Enforce namespaces: %s", mnt.enforceNamespaces)
+	log.Infof("Enforce namespaces: %t", mnt.enforceNamespaces)
 	if mnt.enforceNamespaces {
-		log.Info("Enforcing artifact namespace to be under %s", settings.namespace)
+		log.Infof("Enforcing artifact namespace to be under %s", settings.namespace)
 		artifactRoot = path.Join(pluginData, settings.namespace, artifactDir)
 	}
 

--- a/pkg/oras/settings_test.go
+++ b/pkg/oras/settings_test.go
@@ -1,0 +1,93 @@
+package oras
+
+import "testing"
+
+func TestReferenceParseSimple(t *testing.T) {
+
+	ref := "oras://example.io/mycontainer:latest"
+	var settings orasSettings
+	err := settings.parseReference(ref)
+	if err != nil {
+		t.Errorf("Error parsing reference: %s", err.Error())
+	}
+}
+
+// Write a table driven test for the parseReference function
+// validate the output of the registry, reference, and tag
+func TestReferenceParse(t *testing.T) {
+	tests := []struct {
+		name              string
+		ref               string
+		wantErr           bool
+		expectedRegistry  string
+		expectedReference string
+		expectedTag       string
+	}{
+		{
+			name:              "valid reference",
+			ref:               "oras://example.io/mycontainer:latest",
+			wantErr:           false,
+			expectedRegistry:  "example.io",
+			expectedReference: "example.io/mycontainer",
+			expectedTag:       "latest",
+		},
+		{
+			name:              "no tag",
+			ref:               "oras://example.io/mycontainer",
+			expectedRegistry:  "example.io",
+			expectedReference: "example.io/mycontainer",
+			expectedTag:       "latest",
+			wantErr:           false,
+		},
+		{
+			name:              "bad reference",
+			ref:               "oras://example.io/mycontainer:latest:latest",
+			wantErr:           true,
+			expectedRegistry:  "",
+			expectedReference: "",
+			expectedTag:       "",
+		},
+		{
+			name:              "ubuntu no tag and no registry",
+			ref:               "ubuntu",
+			expectedRegistry:  "docker.io",
+			expectedReference: "docker.io/library/ubuntu",
+			expectedTag:       "latest",
+			wantErr:           false,
+		},
+		{
+			name:              "docker.io/library/ubuntu",
+			ref:               "docker.io/library/ubuntu",
+			expectedRegistry:  "docker.io",
+			expectedReference: "docker.io/library/ubuntu",
+			expectedTag:       "latest",
+			wantErr:           false,
+		},
+		{
+			name:              "localhost and port",
+			ref:               "localhost:5001/artifact:latest",
+			expectedRegistry:  "localhost:5001",
+			expectedReference: "localhost:5001/artifact",
+			expectedTag:       "latest",
+			wantErr:           false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var settings orasSettings
+			if err := settings.parseReference(tt.ref); (err != nil) != tt.wantErr {
+				t.Errorf("parseReference() error = %v, wantErr %v", err, tt.wantErr)
+			} else if !tt.wantErr {
+				if settings.registry != tt.expectedRegistry {
+					t.Errorf("parseReference() registry = %v, expectedRegistry %v", settings.registry, tt.expectedRegistry)
+				}
+				if settings.reference != tt.expectedReference {
+					t.Errorf("parseReference() reference = %v, expectedReference %v", settings.reference, tt.expectedReference)
+				}
+				if settings.tag != tt.expectedTag {
+					t.Errorf("parseReference() tag = %v, expectedTag %v", settings.tag, tt.expectedTag)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
For the driver to work with a registry of the form `kind-registry:5000/myartifact:latest` the parsing needs to handle portl 

```
time="2023-04-17T23:28:35Z" level=info msg="Preparing to pull from remote repository: kind-registry:5000/github-ci"
time="2023-04-17T23:28:35Z" level=info msg="Plain http: true"
time="2023-04-17T23:28:35Z" level=info msg="Found digest: sha256:5d6742ff0b10c1196202765dafb43275259bcbdbd3868c19ba1d19476c088867 for latest"
time="2023-04-17T23:28:35Z" level=info msg="Pulling sha256:acb1ec674e686f4ba7a0e5c0ce1d41b6c2a5f5f1b9b9baca9c612f794faa3f8e, 0 of 1"
time="2023-04-17T23:28:35Z" level=info msg="OCI: Writing sha256:acb1ec674e686f4ba7a0e5c0ce1d41b6c2a5f5f1b9b9baca9c612f794faa3f8e to /pv_data/default/kind-registry:5000-github-ci-latest/container.sif"
time="2023-04-17T23:28:35Z" level=info msg="Oras artifact root: /pv_data/default/kind-registry:5000-github-ci-latest"
time="2023-04-17T23:28:35Z" level=info msg="Found artifact asset: container.sif"
time="2023-04-17T23:28:35Z" level=info msg="volume source directory:/pv_data/default/kind-registry:5000-github-ci-latest"
time="2023-04-17T23:28:35Z" level=info msg="volume target directory:/var/lib/kubelet/pods/b713b715-f675-410a-a3c0-7ea45b7bfe10/volumes/kubernetes.io~csi/oras-inline/mount"
time="2023-04-17T23:28:35Z" level=info msg="volume options:[ro]"
time="2023-04-17T23:28:35Z" level=info msg="BindMount - source: /pv_data/default/kind-registry:5000-github-ci-latest, target: /var/lib/kubelet/pods/b713b715-f675-410a-a3c0-7ea45b7bfe10/volumes/kubernetes.io~csi/oras-inline/mount, options: [ro]"
time="2023-04-17T23:28:35Z" level=info msg="mount -o bind /pv_data/default/kind-registry:5000-github-ci-latest /var/lib/kubelet/pods/b713b715-f675-410a-a3c0-7ea45b7bfe10/volumes/kubernetes.io~csi/oras-inline/mount"
time="2023-04-17T23:28:35Z" level=info msg="Successfully mounted /pv_data/default/kind-registry:5000-github-ci-latest to /var/lib/kubelet/pods/b713b715-f675-410a-a3c0-7ea45b7bfe10/volumes/kubernetes.io~csi/oras-inline/mount"
time="2023-04-17T23:28:35Z" level=info msg="Mount had no errors"
time="2023-04-17T23:28:35Z" level=info msg="returning NodePublishVolumeResponse"
```